### PR TITLE
Feat/zabbix

### DIFF
--- a/app/docs/(server)/zabbix/page.mdx
+++ b/app/docs/(server)/zabbix/page.mdx
@@ -35,7 +35,7 @@ sudo apt upgrade
 ### เพิ่ม Zabbix Repository
 
 ```bash
-wget https://repo.zabbix.com/zabbix/7.0/ubuntu/pool/main/z/zabbix-release/zabbix/release_latest_7.0+ubuntu24.04_all.deb
+wget https://repo.zabbix.com/zabbix/7.0/ubuntu/pool/main/z/zabbix-release/zabbix-release_latest_7.0+ubuntu24.04_all.deb
 sudo dpkg -i zabbix-release_latest_7.0+ubuntu24.04_all.deb
 sudo apt update
 ```

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": false
+  }
+}


### PR DESCRIPTION
Merge: repository path fix and deployment config

- Corrected Zabbix repo URL to 'zabbix-release_latest_7.0+ubuntu24.04_all.deb'
- Introduced vercel.json with deploymentEnabled set to false